### PR TITLE
Bust local plugin cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,10 @@ IMAGE_TAG := kingdonb/jenkins:$(TAG)
 build:
 	docker build . -t $(IMAGE_TAG)
 
+.PHONY: bust-cache
+bust-cache:
+	docker build --no-cache . -t $(IMAGE_TAG)
+
 .PHONY: push
 push: build
 	docker push $(IMAGE_TAG)

--- a/jenkins/docker-build.sh
+++ b/jenkins/docker-build.sh
@@ -23,6 +23,6 @@ GIT_COMMIT_SHORT=$(echo $GIT_COMMIT|cut -c1-8)
 
 IMAGE_TAG=${DOCKER_REPO_HOST}/${DOCKER_REPO_USER}/${DOCKER_REPO_PROJ}:${GIT_COMMIT_SHORT}
 
-docker build -t ${IMAGE_TAG} .
+docker build --no-cache -t ${IMAGE_TAG} .
 
-# make build IMAGE_TAG=${IMAGE_TAG}
+# make bust-cache IMAGE_TAG=${IMAGE_TAG}


### PR DESCRIPTION
In spite of the fact that I've been building Jenkins images periodically, I still get cached images, because I only have one build node and nothing is cleaning its docker store.

We would like each Jenkins build to download the plugins again, for better or for worse. It would be best if the plugins themselves could be cached a-la-buildkit cache volumes, but for now this will permit Jenkins builds to retrieve fresh plugins and resolve this problem:

<img width="1056" alt="Screen Shot 2021-09-03 at 12 32 02 PM" src="https://user-images.githubusercontent.com/3286998/132038908-2e52c494-3199-418c-8255-5a11228e4092.png">

This is what it looks like after a build triggers without `--no-cache`. The build seems to take about 30s so, I think we can stand to repeat the download once every couple of days or whenever it's time to roll the Jenkins LTS server image to get plugins upgraded.

Can always re-evaluate this decision if the plugin list ever grows much longer than it is now.